### PR TITLE
Update ServiceNow pack to use pysnow and add default_payload config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ An example pack has been included in this pack to show the integration of Servic
 * `instance_name` - Upstream Instance Name (e.x.: stackstorm)
 * `username` - Username of service account
 * `password` - Password of service account
+* `default_payload` - Common supported parameters that will be passed to all calls. [Example](http://wiki.servicenow.com/index.php?title=Table_API#Methods)
 
 ### Incoming Integration
 

--- a/actions/approve_change.py
+++ b/actions/approve_change.py
@@ -4,8 +4,6 @@ from lib.actions import BaseAction
 class ApprovalAction(BaseAction):
     def run(self, number):
         s = self.client
-        s.table = 'change_request'
-        res = s.get({'number': number})
-        sys_id = res[0]['sys_id']
-        response = s.update({'approval': 'approved'}, sys_id)
+        r = s.query(table='change_request', query={'number': number}).get_one()
+        response = r.update({'approval': 'approved'})
         return response

--- a/actions/delete.py
+++ b/actions/delete.py
@@ -3,6 +3,6 @@ from lib.actions import BaseAction
 
 class DeleteAction(BaseAction):
     def run(self, table, sysid):
-        self.client.table = table  # pylint: disable=no-member
-        response = self.client.delete(sysid)  # pylint: disable=no-member
+        r = self.client.query(table=table, query={'sys_id': sys_id}) # pylint: disable=no-member
+        response = r.delete()  # pylint: disable=no-member
         return response

--- a/actions/delete.py
+++ b/actions/delete.py
@@ -3,6 +3,7 @@ from lib.actions import BaseAction
 
 class DeleteAction(BaseAction):
     def run(self, table, sysid):
-        r = self.client.query(table=table, query={'sys_id': sysid})  # pylint: disable=no-member
+        s = self.client
+        r = s.query(table=table, query={'sys_id': sysid})  # pylint: disable=no-member
         response = r.delete()  # pylint: disable=no-member
         return response

--- a/actions/delete.py
+++ b/actions/delete.py
@@ -3,6 +3,6 @@ from lib.actions import BaseAction
 
 class DeleteAction(BaseAction):
     def run(self, table, sysid):
-        r = self.client.query(table=table, query={'sys_id': sysid}) # pylint: disable=no-member
+        r = self.client.query(table=table, query={'sys_id': sysid})  # pylint: disable=no-member
         response = r.delete()  # pylint: disable=no-member
         return response

--- a/actions/delete.py
+++ b/actions/delete.py
@@ -3,6 +3,6 @@ from lib.actions import BaseAction
 
 class DeleteAction(BaseAction):
     def run(self, table, sysid):
-        r = self.client.query(table=table, query={'sys_id': sys_id}) # pylint: disable=no-member
+        r = self.client.query(table=table, query={'sys_id': sysid}) # pylint: disable=no-member
         response = r.delete()  # pylint: disable=no-member
         return response

--- a/actions/get.py
+++ b/actions/get.py
@@ -3,6 +3,9 @@ from lib.actions import BaseAction
 
 class GetAction(BaseAction):
     def run(self, table, query):
-        self.client.table = table  # pylint: disable=no-member
-        response = self.client.get(query)  # pylint: disable=no-member
-        return response
+        r = self.client.query(table=table, query=query)  # pylint: disable=no-member
+        response = self.client.get_all()  # pylint: disable=no-member
+        output = []
+        for each_item in response:
+          output.append(each_item)
+        return outrp

--- a/actions/get.py
+++ b/actions/get.py
@@ -3,7 +3,8 @@ from lib.actions import BaseAction
 
 class GetAction(BaseAction):
     def run(self, table, query):
-        r = self.client.query(table=table, query=query)  # pylint: disable=no-member
+        s = self.client
+        r = s.query(table=table, query=query)  # pylint: disable=no-member
         response = r.get_all()  # pylint: disable=no-member
         output = []
         for each_item in response:

--- a/actions/get.py
+++ b/actions/get.py
@@ -4,8 +4,8 @@ from lib.actions import BaseAction
 class GetAction(BaseAction):
     def run(self, table, query):
         r = self.client.query(table=table, query=query)  # pylint: disable=no-member
-        response = self.client.get_all()  # pylint: disable=no-member
+        response = r.get_all()  # pylint: disable=no-member
         output = []
         for each_item in response:
-          output.append(each_item)
+            output.append(each_item)
         return output

--- a/actions/get.py
+++ b/actions/get.py
@@ -8,4 +8,4 @@ class GetAction(BaseAction):
         output = []
         for each_item in response:
           output.append(each_item)
-        return outrp
+        return output

--- a/actions/get_non_structured.py
+++ b/actions/get_non_structured.py
@@ -3,6 +3,9 @@ from lib.actions import BaseAction
 
 class GetNonStructuredAction(BaseAction):
     def run(self, table, query):
-        self.client.table = table  # pylint: disable=no-member
-        response = self.client.get(str(query))  # pylint: disable=no-member
-        return response
+        r = self.client.query(table=table, query=str(query))  # pylint: disable=no-member
+        response = self.client.get_all()  # pylint: disable=no-member
+        output = []
+        for each_item in response:
+          output.append(each_item)
+        return outrp

--- a/actions/get_non_structured.py
+++ b/actions/get_non_structured.py
@@ -4,8 +4,8 @@ from lib.actions import BaseAction
 class GetNonStructuredAction(BaseAction):
     def run(self, table, query):
         r = self.client.query(table=table, query=str(query))  # pylint: disable=no-member
-        response = self.client.get_all()  # pylint: disable=no-member
+        response = r.get_all()  # pylint: disable=no-member
         output = []
         for each_item in response:
-          output.append(each_item)
+            output.append(each_item)
         return output

--- a/actions/get_non_structured.py
+++ b/actions/get_non_structured.py
@@ -8,4 +8,4 @@ class GetNonStructuredAction(BaseAction):
         output = []
         for each_item in response:
           output.append(each_item)
-        return outrp
+        return output

--- a/actions/get_non_structured.py
+++ b/actions/get_non_structured.py
@@ -3,7 +3,8 @@ from lib.actions import BaseAction
 
 class GetNonStructuredAction(BaseAction):
     def run(self, table, query):
-        r = self.client.query(table=table, query=str(query))  # pylint: disable=no-member
+        s = self.client
+        r = s.query(table=table, query=str(query))  # pylint: disable=no-member
         response = r.get_all()  # pylint: disable=no-member
         output = []
         for each_item in response:

--- a/actions/insert.py
+++ b/actions/insert.py
@@ -3,6 +3,5 @@ from lib.actions import BaseAction
 
 class InsertAction(BaseAction):
     def run(self, table, payload):
-        self.client.table = table  # pylint: disable=no-member
-        response = self.client.insert(payload)  # pylint: disable=no-member
+        response = self.client.insert(table=table, payload=payload)  # pylint: disable=no-member
         return response

--- a/actions/insert.py
+++ b/actions/insert.py
@@ -3,5 +3,6 @@ from lib.actions import BaseAction
 
 class InsertAction(BaseAction):
     def run(self, table, payload):
-        response = self.client.insert(table=table, payload=payload)  # pylint: disable=no-member
+        s = self.client
+        response = s.insert(table=table, payload=payload)  # pylint: disable=no-member
         return response

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -1,5 +1,5 @@
 from st2actions.runners.pythonrunner import Action
-import servicenow_rest.api as sn
+import pysnow as sn
 
 
 class BaseAction(Action):
@@ -7,9 +7,14 @@ class BaseAction(Action):
         super(BaseAction, self).__init__(config)
         self.client = self._get_client()
 
-    def _get_client(self):
+    def _get_client(self, default_payload=None):
         instance_name = self.config['instance_name']
         username = self.config['username']
         password = self.config['password']
+        if self.config['default_payload']:
+            default_payload = self.config['default_payload']
 
-        return sn.Client(instance_name, username, password)
+        return sn.Client(instance_name, username, password, default_payload=default_payload)
+
+    def get_client_with_default_payload(default_payload):
+        self.client = self._get_client(default_payload)

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -11,7 +11,7 @@ class BaseAction(Action):
         instance_name = self.config['instance_name']
         username = self.config['username']
         password = self.config['password']
-        if not default_payload and self.config['default_payload']:
+        if not default_payload and 'default_payload' in self.config:
             default_payload = self.config['default_payload']
 
         return sn.Client(instance_name, username, password, default_payload=default_payload)

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -11,7 +11,7 @@ class BaseAction(Action):
         instance_name = self.config['instance_name']
         username = self.config['username']
         password = self.config['password']
-        if self.config['default_payload']:
+        if not default_payload and self.config['default_payload']:
             default_payload = self.config['default_payload']
 
         return sn.Client(instance_name, username, password, default_payload=default_payload)

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -16,5 +16,5 @@ class BaseAction(Action):
 
         return sn.Client(instance_name, username, password, default_payload=default_payload)
 
-    def get_client_with_default_payload(default_payload):
+    def get_client_with_default_payload(self, default_payload):
         self.client = self._get_client(default_payload)

--- a/actions/set_incident_owner.py
+++ b/actions/set_incident_owner.py
@@ -4,8 +4,6 @@ from lib.actions import BaseAction
 class AssignIncidentToAction(BaseAction):
     def run(self, user_id, number):
         s = self.client
-        s.table = 'incident'
-        res = s.get({'number': number})
-        sys_id = res[0]['sys_id']
-        response = s.update({'assigned_to': user_id}, sys_id)
+        r = s.query(table='incident', query={'number': number}).get_one()
+        response = r.update({'assigned_to': user_id})
         return response

--- a/actions/update.py
+++ b/actions/update.py
@@ -3,6 +3,6 @@ from lib.actions import BaseAction
 
 class UpdateAction(BaseAction):
     def run(self, table, payload, sysid):
-        self.client.table = table  # pylint: disable=no-member
-        response = self.client.update(payload, sysid)  # pylint: disable=no-member
+        r = self.client.query(table=table, query={'sys_id': sys_id}).get_one() # pylint: disable=no-member
+        response = r.update(payload)  # pylint: disable=no-member
         return response

--- a/actions/update.py
+++ b/actions/update.py
@@ -3,6 +3,6 @@ from lib.actions import BaseAction
 
 class UpdateAction(BaseAction):
     def run(self, table, payload, sysid):
-        r = self.client.query(table=table, query={'sys_id': sys_id}).get_one() # pylint: disable=no-member
+        r = self.client.query(table=table, query={'sys_id': sysid}).get_one() # pylint: disable=no-member
         response = r.update(payload)  # pylint: disable=no-member
         return response

--- a/actions/update.py
+++ b/actions/update.py
@@ -3,6 +3,6 @@ from lib.actions import BaseAction
 
 class UpdateAction(BaseAction):
     def run(self, table, payload, sysid):
-        r = self.client.query(table=table, query={'sys_id': sysid}).get_one() # pylint: disable=no-member
+        r = self.client.query(table=table, query={'sys_id': sysid}).get_one()  # pylint: disable=no-member
         response = r.update(payload)  # pylint: disable=no-member
         return response

--- a/actions/update.py
+++ b/actions/update.py
@@ -3,6 +3,7 @@ from lib.actions import BaseAction
 
 class UpdateAction(BaseAction):
     def run(self, table, payload, sysid):
-        r = self.client.query(table=table, query={'sys_id': sysid}).get_one()  # pylint: disable=no-member
+        s = self.client
+        r = s.query(table=table, query={'sys_id': sysid}).get_one()  # pylint: disable=no-member
         response = r.update(payload)  # pylint: disable=no-member
         return response

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -13,3 +13,8 @@
     type: "string"
     secret: true
     required: true
+  default_payload:
+    description: "ServiceNow options that will be passed to all requests"
+    type: object
+    required: false
+    

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,6 +3,6 @@
 ref: servicenow
 name: servicenow
 description: ServiceNow Integration Pack
-version: 0.2.0
+version: 0.3.0
 author: James Fryman
 email: james@stackstorm.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-servicenow_rest
+pysnow


### PR DESCRIPTION
The [servicenow_rest](https://github.com/rbw0/python-servicenow-rest) python library has been rewritten by the author to [pysnow](https://github.com/rbw0/pysnow). This PR changes all the functions to use the new library functions. 

It also adds support for adding a default_payload, either on the config or on demand by the actions. This can be used to set the limit of items returned by servicenow or other control features. 