### PR TITLE
We don't need to get_one() to update content

### DIFF
--- a/actions/approve_change.py
+++ b/actions/approve_change.py
@@ -4,6 +4,6 @@ from lib.actions import BaseAction
 class ApprovalAction(BaseAction):
     def run(self, number):
         s = self.client
-        r = s.query(table='change_request', query={'number': number}).get_one()
+        r = s.query(table='change_request', query={'number': number})
         response = r.update({'approval': 'approved'})
         return response

--- a/actions/set_incident_owner.py
+++ b/actions/set_incident_owner.py
@@ -4,6 +4,6 @@ from lib.actions import BaseAction
 class AssignIncidentToAction(BaseAction):
     def run(self, user_id, number):
         s = self.client
-        r = s.query(table='incident', query={'number': number}).get_one()
+        r = s.query(table='incident', query={'number': number})
         response = r.update({'assigned_to': user_id})
         return response

--- a/actions/update.py
+++ b/actions/update.py
@@ -4,6 +4,6 @@ from lib.actions import BaseAction
 class UpdateAction(BaseAction):
     def run(self, table, payload, sysid):
         s = self.client
-        r = s.query(table=table, query={'sys_id': sysid}).get_one()  # pylint: disable=no-member
+        r = s.query(table=table, query={'sys_id': sysid})  # pylint: disable=no-member
         response = r.update(payload)  # pylint: disable=no-member
         return response

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,6 +3,6 @@
 ref: servicenow
 name: servicenow
 description: ServiceNow Integration Pack
-version: 0.3.0
+version: 0.3.1
 author: James Fryman
 email: james@stackstorm.com


### PR DESCRIPTION
the r.update() action has to be done with the query() object and not with the query().get_one(). This new code actually updates the servicenow item