### PR TITLE
Make client definition comply with pysnow 0.6.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.4
+
+- Updated client and pin `pysnow` to 0.6.5
+
 ## 0.3.2
 
 - Added example configuration file

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -7,14 +7,9 @@ class BaseAction(Action):
         super(BaseAction, self).__init__(config)
         self.client = self._get_client()
 
-    def _get_client(self, default_payload=None):
+    def _get_client(self):
         instance_name = self.config['instance_name']
         username = self.config['username']
         password = self.config['password']
-        if not default_payload and 'default_payload' in self.config:
-            default_payload = self.config['default_payload']
 
-        return sn.Client(instance_name, username, password, default_payload=default_payload)
-
-    def get_client_with_default_payload(self, default_payload):
-        self.client = self._get_client(default_payload)
+        return sn.Client(instance=instance_name, user=username, password=password)

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description: ServiceNow Integration Pack
 keywords:
   - servicenow
   - incident management
-version: 0.3.3
+version: 0.3.4
 author: James Fryman
 email: james@stackstorm.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pysnow
+pysnow==0.6.5

--- a/servicenow.yaml.example
+++ b/servicenow.yaml.example
@@ -2,4 +2,3 @@
 instance_name: "StackStorm"
 username: "st2"
 password: "Sup3rS3cr3t"
-default_payload: {}


### PR DESCRIPTION
As defined in their docs:

http://pysnow.readthedocs.io/en/latest/api/client.html#pysnow.client.Client

Also pinned the package version in `requirements.txt` for good measure going forward.