### PR TITLE
Update default_payload configuration to use custom_params instead

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.5
+
+- Allow `custom_params` to be passed to the client
+
 ## 0.3.4
 
 - Updated client and pin `pysnow` to 0.6.5

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Copy the example configuration [servicenow.yaml.example](./servicenow.yaml.examp
 * `instance_name` - Upstream Instance Name (e.x.: stackstorm)
 * `username` - Username of service account
 * `password` - Password of service account
-* `default_payload` - Common supported parameters that will be passed to all calls. [Example](http://wiki.servicenow.com/index.php?title=Table_API#Methods)
+* `custom_params` - Common supported parameters that will be passed to all calls. [Example](https://developer.servicenow.com/app.do#!/rest_api_doc?v=jakarta&id=c_TableAPI)
 
 **Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
            remember to tell StackStorm to load these new values by running

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -12,4 +12,9 @@ class BaseAction(Action):
         username = self.config['username']
         password = self.config['password']
 
-        return sn.Client(instance=instance_name, user=username, password=password)
+        s = sn.Client(instance=instance_name, user=username, password=password)
+
+        if 'custom_params' in self.config:
+            s.parameters.add_custom(self.config['custom_params'])
+
+        return s

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -12,9 +12,9 @@ class BaseAction(Action):
         username = self.config['username']
         password = self.config['password']
 
-        s = sn.Client(instance=instance_name, user=username, password=password)
+        client = sn.Client(instance=instance_name, user=username, password=password)
 
-        if 'custom_params' in self.config:
-            s.parameters.add_custom(self.config['custom_params'])
+        if 'custom_params' in self.config and isinstance(self.config['custom_params'], dict):
+            client.parameters.add_custom(self.config['custom_params'])
 
-        return s
+        return client

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -13,8 +13,7 @@
     type: "string"
     secret: true
     required: true
-  default_payload:
+  custom_params:
     description: "ServiceNow options that will be passed to all requests"
     type: object
     required: false
-    

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description: ServiceNow Integration Pack
 keywords:
   - servicenow
   - incident management
-version: 0.3.4
+version: 0.3.5
 author: James Fryman
 email: james@stackstorm.com


### PR DESCRIPTION
I had some time to review this and I broke some existing functionality in my last patch. Although passing `default_params` to the client during initialisation had been deprecated it's still possible to add custom parameters to the client through methods detailed [here](http://pysnow.readthedocs.io/en/stable/usage/parameters.html).