### PR TITLE
Create a new action to create a record in a ServiceNow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.6
+
+- Add new action create_record
+
 ## 0.3.5
 
 - Allow `custom_params` to be passed to the client

--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ Content-Type: application/json
 * `servicenow.set_incident_owner` - Set the owner of an incident record
 * `servicenow.insert` - Insert an entry to a ServiceNow Table
 * `servicenow.delete` - Delete an entry from a ServiceNow Table
+* `servicenow.create_record` - Create an entry to a ServiceNow Table

--- a/actions/create_record.py
+++ b/actions/create_record.py
@@ -1,0 +1,11 @@
+from lib.actions import BaseAction
+
+
+class CreateRecordAction(BaseAction):
+    def run(self, table, payload):
+        s = self.client
+
+        path = '/table/{0}'.format(table)
+        response = s.resource(api_path=path).create(payload=payload)  # pylint: disable=no-member
+        return 
+

--- a/actions/create_record.py
+++ b/actions/create_record.py
@@ -6,6 +6,5 @@ class CreateRecordAction(BaseAction):
         s = self.client
 
         path = '/table/{0}'.format(table)
-        response = s.resource(api_path=path).create(payload=payload)  # pylint: disable=no-member
-        return 
-
+        s.resource(api_path=path).create(payload=payload)  # pylint: disable=no-member
+        return

--- a/actions/create_record.yaml
+++ b/actions/create_record.yaml
@@ -1,0 +1,16 @@
+---
+name: "create_record"
+runner_type: "python-script"
+description: "Create a record to a ServiceNow Table"
+enabled: true
+entry_point: "create_record.py"
+parameters:
+  table:
+    type: "string"
+    description: "Table to take action on"
+    required: true
+  payload:
+    type: "object"
+    description: "Data to upload to ServiceNow"
+    required: true
+

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description: ServiceNow Integration Pack
 keywords:
   - servicenow
   - incident management
-version: 0.3.5
+version: 0.3.6
 author: James Fryman
 email: james@stackstorm.com


### PR DESCRIPTION
New action calls resource() instead of insert to avoid to use deprecated method.

Warning message from insert action:
/opt/stackstorm/virtualenvs/servicenow/lib/python2.7/site-packages/pysnow/client.py:120: DeprecationWarning: `insert` is deprecated and will be removed in a future release. Please use `resource()` instead.
"Please use `resource()` instead." % inspect.stack()[1][3], DeprecationWarning)