### PR TITLE
Fix incorrect pack reporting if no config [#13]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.3.8
+- Ensure action's config is configured with packname
+
 ## 0.3.7
 - Add pack name to create_record
 - Return response from create_record action

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -3,8 +3,8 @@ import pysnow as sn
 
 
 class BaseAction(Action):
-    def __init__(self, config):
-        super(BaseAction, self).__init__(config)
+    def __init__(self, config=None, action_service=None):
+        super(BaseAction, self).__init__(config, action_service)
         self.client = self._get_client()
 
     def _get_client(self):

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description: ServiceNow Integration Pack
 keywords:
   - servicenow
   - incident management
-version: 0.3.7
+version: 0.3.8
 python_versions:
   - "2"
   - "3"

--- a/tests/fixtures/full.yaml
+++ b/tests/fixtures/full.yaml
@@ -1,0 +1,4 @@
+---
+instance_name: "instancename"
+username: "snuser"
+password: "snpass"

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -37,7 +37,7 @@ class ServiceNowActionTestCase(BaseActionTestCase):
         return self._full_config
 
     def test_get_instance_with_config(self):
-        action = self.get_action_instance(self.full_config)
+        self.get_action_instance(self.full_config)
 
     def test_get_instance_without_config(self):
         # Use try/except as self.assertRaises wasn't matching

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,0 +1,49 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+import yaml
+import sys
+sys.modules['pysnow'] = mock.Mock()
+
+from st2tests.base import BaseActionTestCase
+from get_non_structured import GetNonStructuredAction
+
+
+class ServiceNowActionTestCase(BaseActionTestCase):
+
+    action_cls = GetNonStructuredAction
+
+    def setUp(self):
+        super(ServiceNowActionTestCase, self).setUp()
+        self._full_config = self.load_yaml('full.yaml')
+
+    def load_yaml(self, filename):
+        return yaml.safe_load(self.get_fixture_content(filename))
+
+    @property
+    def full_config(self):
+        return self._full_config
+
+    def test_get_instance_with_config(self):
+        action = self.get_action_instance(self.full_config)
+
+    def test_get_instance_without_config(self):
+        # Use try/except as self.assertRaises wasn't matching
+        try:
+            self.get_action_instance(None)
+            self.fail("Expection exception not thrown")
+        except ValueError as e:
+            self.assertTrue('Config for pack "tests" is missing' in e.args[0],
+                            e.args)


### PR DESCRIPTION
Amend the action initialiser so that the action_service is passed, which for instance will ensure that the pack name is known in errors raised.