### PR TITLE
Add attachment support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.3.9
+- Add support for upload attachment and get attachment metadata
+
 ## 0.3.8
 - Ensure action's config is configured with packname
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 0.3.9
+## 0.4.0
 - Add support for upload attachment and get attachment metadata
 
 ## 0.3.8

--- a/README.md
+++ b/README.md
@@ -51,3 +51,6 @@ Content-Type: application/json
 * `servicenow.insert` - Insert an entry to a ServiceNow Table
 * `servicenow.delete` - Delete an entry from a ServiceNow Table
 * `servicenow.create_record` - Create an entry to a ServiceNow Table
+* `servicenow.get_attachments` - Gets the metadata of all attachments to a ServiceNow Table
+* `servicenow.get_attachment` - Gets the metadata of an attachment on a ServiceNow Table
+* `servicenow.upload_attachment` - Uploads an attachment to an entry on a ServiceNow Table

--- a/actions/get_attachment.py
+++ b/actions/get_attachment.py
@@ -1,0 +1,13 @@
+from lib.actions import BaseAction
+
+
+class GetAttachmentAction(BaseAction):
+    def run(self, table, sys_id):
+        s = self.client
+        api_path = "/attachment/{}".format(sys_id)
+        r = s.resource(api_path=api_path)
+        records = r.get(query={})
+        output = []
+        for record in records.all():
+            output.append(record)
+        return output

--- a/actions/get_attachment.py
+++ b/actions/get_attachment.py
@@ -2,12 +2,5 @@ from lib.actions import BaseAction
 
 
 class GetAttachmentAction(BaseAction):
-    def run(self, table, sys_id):
-        s = self.client
-        api_path = "/attachment/{}".format(sys_id)
-        r = s.resource(api_path=api_path)
-        records = r.get(query={})
-        output = []
-        for record in records.all():
-            output.append(record)
-        return output
+    def run(self, sys_id):
+        return self.get_attachments(sys_id)

--- a/actions/get_attachment.yaml
+++ b/actions/get_attachment.yaml
@@ -1,0 +1,15 @@
+---
+name: "get_attachment"
+runner_type: "python-script"
+description: "Gets metadata for an attachment"
+enabled: true
+entry_point: "get_attachment.py"
+parameters:
+  table:
+    type: "string"
+    description: "Table to take action on"
+    required: true
+  sys_id:
+    type: "string"
+    description: "Sys-id of attachment to retrieve"
+    required: true

--- a/actions/get_attachment.yaml
+++ b/actions/get_attachment.yaml
@@ -5,10 +5,6 @@ description: "Gets metadata for an attachment"
 enabled: true
 entry_point: "get_attachment.py"
 parameters:
-  table:
-    type: "string"
-    description: "Table to take action on"
-    required: true
   sys_id:
     type: "string"
     description: "Sys-id of attachment to retrieve"

--- a/actions/get_attachments.py
+++ b/actions/get_attachments.py
@@ -1,0 +1,12 @@
+from lib.actions import BaseAction
+
+
+class GetAttachmentsAction(BaseAction):
+    def run(self, table):
+        s = self.client
+        r = s.resource(api_path="/attachment")
+        records = r.get(query={})
+        output = []
+        for record in records.all():
+            output.append(record)
+        return output

--- a/actions/get_attachments.py
+++ b/actions/get_attachments.py
@@ -2,11 +2,5 @@ from lib.actions import BaseAction
 
 
 class GetAttachmentsAction(BaseAction):
-    def run(self, table):
-        s = self.client
-        r = s.resource(api_path="/attachment")
-        records = r.get(query={})
-        output = []
-        for record in records.all():
-            output.append(record)
-        return output
+    def run(self):
+        return self.get_attachments()

--- a/actions/get_attachments.yaml
+++ b/actions/get_attachments.yaml
@@ -1,0 +1,11 @@
+---
+name: "get_attachments"
+runner_type: "python-script"
+description: "Gets meta-data for all attachments for specified table"
+enabled: true
+entry_point: "get_attachments.py"
+parameters:
+  table:
+    type: "string"
+    description: "Table to take action on"
+    required: true

--- a/actions/get_attachments.yaml
+++ b/actions/get_attachments.yaml
@@ -1,11 +1,6 @@
 ---
 name: "get_attachments"
 runner_type: "python-script"
-description: "Gets meta-data for all attachments for specified table"
+description: "Gets meta-data for all attachments"
 enabled: true
 entry_point: "get_attachments.py"
-parameters:
-  table:
-    type: "string"
-    description: "Table to take action on"
-    required: true

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -20,9 +20,9 @@ class BaseAction(Action):
         return client
 
     def get_attachments(self, sys_id=None):
-        api_path="/attachment"
+        api_path = "/attachment"
         if sys_id:
-            api_path+="/{}".format(sys_id)
+            api_path += "/{}".format(sys_id)
         r = self.client.resource(api_path=api_path)
         records = r.get(query={})
-        return [r for r in records.all()]
+        return [rec for rec in records.all()]

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -18,3 +18,11 @@ class BaseAction(Action):
             client.parameters.add_custom(self.config['custom_params'])
 
         return client
+
+    def get_attachments(self, sys_id=None):
+        api_path="/attachment"
+        if sys_id:
+            api_path+="/{}".format(sys_id)
+        r = self.client.resource(api_path=api_path)
+        records = r.get(query={})
+        return [r for r in records.all()]

--- a/actions/upload_attachment.py
+++ b/actions/upload_attachment.py
@@ -1,0 +1,10 @@
+from lib.actions import BaseAction
+
+import os
+
+class UploadAttachmentAction(BaseAction):
+    def run(self, table, file, sysid):
+        s = self.client
+        r = s.query(table=table, query={'sys_id': sysid})  # pylint: disable=no-member
+        response = r.attach(file)  # pylint: disable=no-member
+        return response

--- a/actions/upload_attachment.py
+++ b/actions/upload_attachment.py
@@ -1,6 +1,5 @@
 from lib.actions import BaseAction
 
-import os
 
 class UploadAttachmentAction(BaseAction):
     def run(self, table, file, sysid):

--- a/actions/upload_attachment.yaml
+++ b/actions/upload_attachment.yaml
@@ -1,0 +1,19 @@
+---
+name: "upload_attachment"
+runner_type: "python-script"
+description: "Uploads an attachment to a record in a ServiceNow Table"
+enabled: true
+entry_point: "upload_attachment.py"
+parameters:
+  table:
+    type: "string"
+    description: "Table to take action on"
+    required: true
+  sysid:
+    type: "string"
+    description: "ID of record"
+    required: true
+  file:
+    type: "string"
+    description: "Path to local file to attach"
+    required: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description: ServiceNow Integration Pack
 keywords:
   - servicenow
   - incident management
-version: 0.3.8
+version: 0.3.9
 python_versions:
   - "2"
   - "3"

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description: ServiceNow Integration Pack
 keywords:
   - servicenow
   - incident management
-version: 0.3.9
+version: 0.4.0
 python_versions:
   - "2"
   - "3"

--- a/tests/servicenow_base_action_test_case.py
+++ b/tests/servicenow_base_action_test_case.py
@@ -1,0 +1,32 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import yaml
+import sys
+
+from st2tests.base import BaseActionTestCase
+
+
+class ServiceNowBaseActionTestCase(BaseActionTestCase):
+
+    def setUp(self):
+        super(ServiceNowBaseActionTestCase, self).setUp()
+        self._full_config = self.load_yaml('full.yaml')
+
+    def load_yaml(self, filename):
+        return yaml.safe_load(self.get_fixture_content(filename))
+
+    @property
+    def full_config(self):
+        return self._full_config

--- a/tests/servicenow_base_action_test_case.py
+++ b/tests/servicenow_base_action_test_case.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 
 import yaml
-import sys
 
 from st2tests.base import BaseActionTestCase
 

--- a/tests/test_upload_attachment.py
+++ b/tests/test_upload_attachment.py
@@ -1,0 +1,37 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+import yaml
+import sys
+
+from servicenow_base_action_test_case import ServiceNowBaseActionTestCase
+from upload_attachment import UploadAttachmentAction
+
+
+class UploadAttachmentActionTestCase(ServiceNowBaseActionTestCase):
+
+    action_cls = UploadAttachmentAction
+
+    def setUp(self):
+        super(UploadAttachmentActionTestCase, self).setUp()
+
+    @mock.patch('pysnow.Client')
+    def test_add_attachment(self, mock_client):
+        action = self.get_action_instance(self.full_config)
+        result = action.run('table1','file1','sysid1')
+        mock_client.return_value.query.assert_called_with(table="table1", query={'sys_id': "sysid1"})
+        mock_client.return_value.query.return_value.attach.assert_called_with('file1')       
+        self.assertIsNotNone(result)
+        self.assertTrue(result[0])

--- a/tests/test_upload_attachment.py
+++ b/tests/test_upload_attachment.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 
 import mock
-import yaml
-import sys
 
 from servicenow_base_action_test_case import ServiceNowBaseActionTestCase
 from upload_attachment import UploadAttachmentAction
@@ -30,8 +28,9 @@ class UploadAttachmentActionTestCase(ServiceNowBaseActionTestCase):
     @mock.patch('pysnow.Client')
     def test_add_attachment(self, mock_client):
         action = self.get_action_instance(self.full_config)
-        result = action.run('table1','file1','sysid1')
-        mock_client.return_value.query.assert_called_with(table="table1", query={'sys_id': "sysid1"})
-        mock_client.return_value.query.return_value.attach.assert_called_with('file1')       
+        result = action.run('table1', 'file1', 'sysid1')
+        mock_client.return_value.query.assert_called_with(table="table1",
+                                                          query={'sys_id': "sysid1"})
+        mock_client.return_value.query.return_value.attach.assert_called_with('file1')
         self.assertIsNotNone(result)
         self.assertTrue(result[0])


### PR DESCRIPTION
Add support to service now attachment actions of:

- GET attachments - returns the meta data of all attachments on the table

- GET attachment <sysid> - returns the meta data for single attachment (including the download link)

- POST attachment <sysid> - uploads an attachment to an entry in a table